### PR TITLE
fix regexp

### DIFF
--- a/fs_to/fs_to.js
+++ b/fs_to/fs_to.js
@@ -842,7 +842,7 @@
 	var fromPage = 0, tryToSearch = true;
 	
 	// 1-link,2-image,3-title,4-genres,5-positive rating,6-negative rating, 7-description
-	var re = /<a href="([\S\s]{0,200}?)"[\S\s]{0,200}?<img src="([\S\s]*?)"[\S\s]*?results-item-title">([\S\s]*?)<\/span>[\S\s]*?results-item-genres">([\S\s]*?)<\/span>[\S\s]*?results-item-rating-positive">([\S\s]*?)<\/span>[\S\s]*?results-item-rating-negative">([\S\s]*?)<\/span>[\S\s]*?results-item-description">([\S\s]*?)<\/span>/g;
+	var re = /<a href="([^"]{0,200}?)"[\S\s]{0,200}?<img src="([\S\s]*?)"[\S\s]*?results-item-title">([\S\s]*?)<\/span>[\S\s]*?results-item-genres">([\S\s]*?)<\/span>[\S\s]*?results-item-rating-positive">([\S\s]*?)<\/span>[\S\s]*?results-item-rating-negative">([\S\s]*?)<\/span>[\S\s]*?results-item-description">([\S\s]*?)<\/span>/g;
 	
 	function loader() {
             if (!tryToSearch) return false;


### PR DESCRIPTION
Search results regexp update.
Not all 100% results of fsto search works.

Search for "ice age 3":
```
navigator       [INFO ]: Opening search:ice age 3
navigator       [INFO ]: Opening prop:27
navigator       [INFO ]: Opening fs.to:listRoot:/video/cartoons/i4FEmDDTXOTdqxt72tvy5Us-lednikovyj-period-3-era-dinozavrov.html%22%20class%3D%22b-search-page__results-item%20m-video:%u041B%u0435%u0434%u043D%u0438%u043A%u043E%u0432%u044B%u0439%20%u043F%u0435%u0440%u0438%u043E%u0434%203%3A%20%u042D%u0440%u0430%20%u0434%u0438%u043D%u043E%u0437%u0430%u0432%u0440%u043E%u0432%20/%20Ice%20Age%3A%20Dawn%20of%20the%20Dinosaurs%20%282009%29
JS              [ERROR]: zip://file:///home/eduard/.hts/showtime/installedplugins/fs.to.zip/fs_to.js:137 Error: HTTP error: 404
```